### PR TITLE
Update usage.rst

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -34,4 +34,5 @@ Results
 
 To **run in the browser** you can simply:
 
-[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://github.com/AntonOsika/gpt-engineer/codespaces)
+.. image:: https://github.com/codespaces/badge.svg
+   :target: https://github.com/AntonOsika/gpt-engineer/codespaces


### PR DESCRIPTION
Fixed the incorrect github codespaces URL in this [page](https://gpt-engineer.readthedocs.io/en/latest/usage.html)